### PR TITLE
Adds a couple more EMR/task variables, plus docs fixes.

### DIFF
--- a/docs/analytics/insights.md
+++ b/docs/analytics/insights.md
@@ -237,6 +237,27 @@ your `vars-analytics.yml`.
   NotFoundError: Resource http://127.0.0.1:8100/api/v0/course_summaries/ was not found on the API server.
   ```
   However, this only affects the home course list page.  The inner course-specific analytics pages will display fine.
+* Even after the `ImportEnrollmentsIntoMysql` task has run, the home page of Insights is still returning a 500 error,
+  and `/edx/var/log/insights/edx.log` shows something like:
+
+  ```bash
+  ClientError: Resource "course_summaries/" returned status code 500
+  ```
+
+  And `/edx/var/log/analytics-api/edx.log` shows something like:
+
+  ```bash
+  TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
+  ```
+
+  This issue happens because the analytics pipeline creates tables and fields that the Analytics API accesses, but it
+  doesn't create them using the default values that the Analytics API expects.  This should be fixed properly in the
+  code someday, but to work around it, run this on the `reports` database:
+
+  ```sql
+  mysql> alter table course_meta_summary_enrollment alter passing_users set default 0;
+  mysql> update course_meta_summary_enrollment set passing_users=0 where passing_users is Null;
+  ```
 * There is no data in Insights - that's actually ok, we haven't run any pipeline tasks yet.
 
 Configure Insights

--- a/docs/analytics/insights.md
+++ b/docs/analytics/insights.md
@@ -130,7 +130,7 @@ sudo -Hu edxapp bash
 cd
 source edxapp_env
 cd edx-platform
-./manage.py lms --setting=aws create_oauth2_client \
+./manage.py lms --setting=$EDX_PLATFORM_SETTINGS create_oauth2_client \
     <INSIGHTS_BASE_URL_PROTOCOL>://<INSIGHTS_BASE_URL> \
     <INSIGHTS_BASE_URL_PROTOCOL>://<INSIGHTS_BASE_URL>/complete/edx-oidc/ \
     confidential --client_name insights \

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -129,7 +129,7 @@ cd $HOME
 TO_DATE=`date +%Y-%m-%d`
 analytics-configuration/automation/run-automated-task.sh ImportEnrollmentsIntoMysql \
     --local-scheduler \
-    --interval "2013-01-01-$TO_DATE" \
+    --interval "$START_DATE-$TO_DATE" \
     --n-reduce-tasks $NUM_REDUCE_TASKS
 ```
 

--- a/docs/analytics/resources/emr-vars.yml
+++ b/docs/analytics/resources/emr-vars.yml
@@ -17,8 +17,8 @@ instance_groups:
     market: ON_DEMAND
 role: EMR_EC2_DefaultRole
 keypair_name: 'analytics'  # your analytics instance key pair name
-vpc_subnet_id: 'subnet-abcd1234'  # public subnet of the VPC
-log_uri: 's3://client-name-analytics-emr/logs'
+vpc_subnet_id: 'subnet-SET ME'  # public subnet of the VPC
+log_uri: "{{ lookup('env', 'TASK_CONFIGURATION_S3_BUCKET') }}/logs"
 release_label: 'emr-4.7.2'
 
 applications:
@@ -47,5 +47,7 @@ steps:
   - type: hive_install
   - type: script
     name: "Install Sqoop"
-    step_args: [ "s3://client-name-analytics-emr/install-sqoop", "s3://client-name-analytics-emr" ]
+    step_args:
+      - "{{ lookup('env', 'TASK_CONFIGURATION_S3_BUCKET') }}/install-sqoop"
+      - "{{ lookup('env', 'TASK_CONFIGURATION_S3_BUCKET') }}"
     action_on_failure: TERMINATE_JOB_FLOW  # Set to CANCEL_AND_WAIT when debugging step failures.

--- a/docs/analytics/resources/jenkins_env
+++ b/docs/analytics/resources/jenkins_env
@@ -5,6 +5,7 @@ export PIP_VIRTUALENV_BASE=/home/jenkins/venvs
 export EXTRA_VARS="@/home/jenkins/emr-vars.yml"
 export WORKSPACE=/home/jenkins/workspace
 export CLUSTER_NAME="Client Name Analytics Cluster"
+export START_DATE="2013-01-01"
 export TASKS_REPO="https://github.com/x/edx-analytics-pipeline.git"
 export TASKS_BRANCH=x
 export TASK_USER=hadoop


### PR DESCRIPTION
Small changes that reduce the number of things we need to do when deploying Insights.

* 0ab867b - reduces the things we need to set in `emr-vars.yml`
* 7e365ad - lets us adjust the start date for the analytics tasks without having to customize the task shell command
* c5d06f0 - lets us run the OAuth2 creation command on our OpenStack edxapp instances
* 22611f7 - provides an SQL workaround to the bug in analytics-api that only occurs if you have no passing students yet.
  We should submit a proper fix to edX for this, but I didn't have time during this task.  For the record, the code fix diff could be: 
    ```diff
    index 431113e..9aecee0 100644
    --- a/analytics_data_api/v0/views/course_summaries.py
    +++ b/analytics_data_api/v0/views/course_summaries.py
    @@ -133,8 +133,9 @@ class CourseSummariesView(APIListView):
             # treat the most recent as the authoritative created date -- should be all the same
             field_dict['created'] = max(model.created, field_dict['created']) if field_dict['created'] else model.created

    -        # update totals for all counts
    -        field_dict.update({field: field_dict[field] + getattr(model, field) for field in self.count_fields})
    +        # update totals for all counts, handling null values as required.
    +        field_dict.update({field: (field_dict[field] or 0) + (getattr(model, field) or 0)
    +                            for field in self.count_fields})

             return field_dict


            # update totals for all counts, handling null values as required.
            field_dict.update({field: (field_dict[field] or 0) + (getattr(model, field) or 0)
                                for field in self.count_fields})
    ```

*Reviewer*
- [ ] @UmanShahzad 