### PR TITLE
Makes Video task intervals more robust

### DIFF
--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -250,10 +250,9 @@ Run on periodic build schedule, e.g. `H 9 * * *`.
 export CLUSTER_NAME="InsertToMysqlAllVideoTask Cluster"
 cd $HOME
 
-FROM_DATE=2010-01-01
-TO_DATE=2030-01-01
+TO_DATE=`date +%Y-%m-%d`
 analytics-configuration/automation/run-automated-task.sh InsertToMysqlAllVideoTask --local-scheduler \
-  --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \
+  --interval "$START_DATE-$TO_DATE" \
   --n-reduce-tasks $NUM_REDUCE_TASKS
 ```
 

--- a/docs/analytics/resources/analytics-override.cfg
+++ b/docs/analytics/resources/analytics-override.cfg
@@ -44,6 +44,7 @@ interval = 2014-01-01-2020-01-01
 
 [videos]
 dropoff_threshold = 0.05
+overwrite_n_days = 3
 
 [elasticsearch]
 host = https://search-client-name-analytics-es-xxxx.us-east-1.es.amazonaws.com


### PR DESCRIPTION
Updates the `InsertToMysqlAllVideoTask` to use the same `--interval "$START_DATE-$TO_DATE"` as the other suggested task configurations.

By removing the hardcoded `$TO_DATE`, and using the client-specific [`$START_DATE` configured in `jenkins_env`](https://github.com/open-craft/openedx-deployment/blob/d53ac5e100da33104d0338d2bc58a97316a53455/docs/analytics/resources/jenkins_env#L8), we can ensure that the Video Engagement data is consistent with the other task's data.

Also adds a suggested `[video] overwrite_n_days = 3` configuration, to match the enrolments overwrite setting.

**Reviewer**
- [ ] @UmanShahzad 