### PR TITLE
Discard old Jenkins task builds

### DIFF
--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -103,9 +103,7 @@ body, and list the environment variables in the actual shell command inline.
 
 In edx docs: [Performance (graded and ungraded)](http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/running_tasks.html#performance-graded-and-ungraded)
 
-Runs nightly.
-
-Run on periodic build schedule, e.g. `H 0 * * *`.
+Run on periodic build schedule, e.g. `H 7 * * *`.
 
 NB: The AnswerDistributionWorkflow task is one of the oldest analytics tasks, and not as cleanly configured as the other
 tasks.  The `--dest`, `--manifest`, and `--marker` parameters must used a timestamped directory, to ensure fresh data
@@ -145,7 +143,7 @@ In edx docs: [Enrollment History Task](http://edx-analytics-pipeline-reference.r
 
 Imports enrollments data; runs daily.
 
-Run on periodic build schedule, e.g. `H 6 * * *`.
+Run on periodic build schedule, e.g. `H 0 * * *`.
 
 ```bash
 . /home/jenkins/jenkins_env
@@ -171,7 +169,7 @@ In edx docs: [Enrollments By Country History task](http://edx-analytics-pipeline
 
 Enrollments by geolocation; runs daily.
 
-Run on periodic build schedule, e.g. `H 12 * * *`.
+Run on periodic build schedule, e.g. `H 5 * * *`.
 
 ```bash
 . /home/jenkins/jenkins_env
@@ -191,7 +189,7 @@ In edx docs: [Engagement](http://edx-analytics-pipeline-reference.readthedocs.io
 
 Weekly course activity; runs every Monday.
 
-Run on periodic build schedule, e.g. `H 3 * * 1`.
+Run on periodic build schedule, e.g. `H 1 * * 1`.
 
 ```bash
 . /home/jenkins/jenkins_env
@@ -241,7 +239,7 @@ In edx docs: [ModuleEngagementWorkflowTask](http://edx-analytics-pipeline-refere
 
 Weekly course module engagement data stored in an ElasticSearch index; runs daily.
 
-Run on periodic build schedule, e.g. `H 15 * * *`.
+Run on periodic build schedule, e.g. `H 3 * * *`.
 
 Note: HKS epodX wanted theirs to run every 2 hours, so for them we use: `H */2 * * *`,
 
@@ -282,7 +280,7 @@ analytics-configuration/automation/run-automated-task.sh InsertToMysqlAllVideoTa
 
 In edx docs: [StudentEngagementCsvFileTask](http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/all.html#edx.analytics.tasks.data_api.student_engagement.StudentEngagementCsvFileTask)
 
-Run on a daily build schedule, e.g. `H 19 * * *`.
+Run on a daily build schedule, e.g. `H 11 * * *`.
 
 Run this task only if your client requires daily Student Engagement reports.
 
@@ -305,7 +303,7 @@ analytics-configuration/automation/run-automated-task.sh StudentEngagementCsvFil
 
 In edx docs: [StudentEngagementCsvFileTask](http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/all.html#edx.analytics.tasks.data_api.student_engagement.StudentEngagementCsvFileTask)
 
-Run on a weekly build schedule, e.g. `H 21 * * 1`.
+Run on a weekly build schedule, e.g. `H 13 * * 1`.
 
 Run this task only if your client requires weekly Student Engagement reports.
 

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -43,6 +43,12 @@ To create job, authenticate to Jenkins, than go to main page.
   For subsequent tasks, you can "Copy from existing item" instead, which saves a lot of steps.
 * `Project name`: set automatically from previous step
 * `Description`: provide appropriate description
+* `Discard Old Builds`: enable
+  `Strategy`: Log Rotation
+  `Days to keep builds`: (leave blank)
+  `Max # of builds to keep`: 50
+  `Advanced: Days to keep artifacts`: (leave blank)
+  `Advanced: Max # of builds to keep with artifacts`: 50
 * `Github project`: (leave blank)
 * `Job Notifications`: use section defaults
 * `Advanced Project Options`: use section defaults

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -40,40 +40,48 @@ To create job, authenticate to Jenkins, than go to main page.
 * Click "New Item" in the left sidebar.
 * Set the task name to be the insights domain, followed by a recognizable name that uniquely identifies the task (e.g. "insights.example.com Module Engagement"). Having the insights domain prepended to the task name will help recipients of the error emails to quickly identify the source analytics instance of any future task failure alerts.
 * If this is the first task created, select "Build a free-style software project"
+
   For subsequent tasks, you can "Copy from existing item" instead, which saves a lot of steps.
 * `Project name`: set automatically from previous step
 * `Description`: provide appropriate description
 * `Discard Old Builds`: enable
-  `Strategy`: Log Rotation
-  `Days to keep builds`: (leave blank)
-  `Max # of builds to keep`: 50
-  `Advanced: Days to keep artifacts`: (leave blank)
-  `Advanced: Max # of builds to keep with artifacts`: 50
+  * `Strategy`: Log Rotation
+  * `Days to keep builds`: (leave blank)
+  * `Max # of builds to keep`: 50
+  * `Advanced: Days to keep artifacts`: (leave blank)
+  * `Advanced: Max # of builds to keep with artifacts`: 50
 * `Github project`: (leave blank)
 * `Job Notifications`: use section defaults
 * `Advanced Project Options`: use section defaults
 * `Source Code Management`: `None`
 * `Build Triggers`: `Build Periodically`
-  `Schedule`: e.g., `H X * * *`, see [Commands](#commands) for suggested schedules.
-    * `X` is an hour to run task (i.e. with X=19 task will run an 19:00 daily),
-    * `H` being Jenkins feature to spread the load
-    * It makes sense to try to produce even load on the server by running tasks throughout the day, i.e. not put them
-      all to `0 0 * * *`, or even `H H * * *` (`H` is a hash, so it might put some tasks closely together).
-    * Refer to Jenkins help should more need for a more sophisticated schedule arise.
+  * `Schedule`: e.g., `H X * * *`, see [Commands](#commands) for suggested schedules.
+    * `X` is an hour to run task (i.e. with X=19 task will run at 19:00 daily)
+    * `H` is a Jenkins hash used to spread the load.
+
+    It makes sense to try to reduce even load on the server by running tasks throughout the day, i.e. not put them all
+    to `0 0 * * *`, or even `H H * * *` (`H` is a hash, so it might put some tasks closely together).
+
+    Refer to Jenkins help should the need for a more sophisticated schedule arise.
 * `Build Environment`
     * `Abort the build if it's stuck`: enable
-      `Time-out strategy`: `Absolute`
-      `Timeout Minutes`: `300`
-    * Click `Add Action` and add `Fail the Build`.
+        * `Time-out strategy`: `Absolute`
+        * `Timeout Minutes`: `300`
+        * Click `Add Action` and add `Fail the Build`.
     * `SSH Agent`: enable
-      `Credentials`: `Specific credentials`: hadoop
-        This allows Jenkins to ssh to the EMR servers via the shell command.
-        Select the 'hadoop' ssh access key created by ansible.
-        If the ssh credentials were not configured via ansible you can manually create a key here by clicking the `Add Key` button.
+      * `Credentials`: `Specific credentials`: hadoop
+
+      This allows Jenkins to ssh to the EMR servers via the shell command.
+
+      Select the 'hadoop' ssh access key created by ansible.
+
+      If the ssh credentials were not configured via ansible you can manually create a key here by clicking       the `Add Key` button.
+
         * Kind: SSH username with private key
         * Scope: Global
         * Username: `hadoop`
-        * Private key: paste the analytics private key file contents directly, or copy the file to the analytics instance and point to the path.
+        * Private key: paste the analytics private key file contents directly, or copy the file to the analytics
+          instance and point to the path.
         * Passphrase: Leave empty for AWS-issued private key files.
         * Description: ssh credential file
 * `Build`

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -37,38 +37,52 @@ Configuring Jenkins job
 
 To create job, authenticate to Jenkins, than go to main page.
 
-* Click "New Item" in the left sidebar. Once you've created the first task, you can "Copy from existing item" instead, which saves a lot of steps.
+* Click "New Item" in the left sidebar.
 * Set the task name to be the insights domain, followed by a recognizable name that uniquely identifies the task (e.g. "insights.example.com Module Engagement"). Having the insights domain prepended to the task name will help recipients of the error emails to quickly identify the source analytics instance of any future task failure alerts.
-* Select "Build a free-style software project"
-* You'll arrive at job configuration page. `Name` should be already set automatically. You might want to give task a description.
-* No modifications required in `Job Notifications` and `Advanced Project Options` sections.
-* `Source Code Management` - `None`
-* `Build Triggers` - `Build Periodically`. `H X * * *` should be good value for `Schedule field`, with X being an hour to run task (i.e. with X=19 task will run an 19:00 daily), `H` being Jenkins feature to spread the load; refer to Jenkins help should more need for a more sophisticated schedule arise.
-* `Build Environment` -> `Abort the build if it's stuck`: Enable this option. Set `Time-out strategy` to `Absolute`, `Timeout Minutes` to `300`. Then click `Add Action` and add a timeout action of `Fail the Build`.
-* `Build Environment` -> `SSH Agent` -> `Credentials` -> `Specific credentials`: This allows Jenkins to ssh to the
-  EMR servers via the shell command. Select the 'hadoop' ssh access key created by ansible. If the ssh credentials were not configured via ansible you can manually create a key here by clicking the
-  `Add Key` button.
-  * Kind: SSH username with private key
-  * Scope: Global
-  * Username: `hadoop`
-  * Private key: paste the analytics private key file contents directly, or copy the file to the analytics instance and point to the path.
-  * Passphrase: Leave empty for AWS-issued private key files.
-  * Description: ssh credential file
-* `Build` -> `Add Step` -> `Execute Shell`.
-* Fill in `Command` field with shell script to run. See [Commands](#commands) for details.
-* `Post build actions` -> `Add post build task` ->
-  * `Log text`: `Traceback`
-  * `Script`: `exit 1`
-  * `Run script only if all previous steps were successful`: `yes`
-  * `Escalate script execution status to job status`: `yes`
-* `Post build actions` -> `Add post build action` -> `Email Notification`
-  * `Recipients` - an alert email address, e.g. `ops@example.com`
-  * `Send e-mail for every unstable build`: `yes`
-  * `Send separate e-mails to individuals who broke the build`: `no`
+* If this is the first task created, select "Build a free-style software project"
+  For subsequent tasks, you can "Copy from existing item" instead, which saves a lot of steps.
+* `Project name`: set automatically from previous step
+* `Description`: provide appropriate description
+* `Github project`: (leave blank)
+* `Job Notifications`: use section defaults
+* `Advanced Project Options`: use section defaults
+* `Source Code Management`: `None`
+* `Build Triggers`: `Build Periodically`
+  `Schedule`: e.g., `H X * * *`, see [Commands](#commands) for suggested schedules.
+    * `X` is an hour to run task (i.e. with X=19 task will run an 19:00 daily),
+    * `H` being Jenkins feature to spread the load
+    * It makes sense to try to produce even load on the server by running tasks throughout the day, i.e. not put them
+      all to `0 0 * * *`, or even `H H * * *` (`H` is a hash, so it might put some tasks closely together).
+    * Refer to Jenkins help should more need for a more sophisticated schedule arise.
+* `Build Environment`
+    * `Abort the build if it's stuck`: enable
+      `Time-out strategy`: `Absolute`
+      `Timeout Minutes`: `300`
+    * Click `Add Action` and add `Fail the Build`.
+    * `SSH Agent`: enable
+      `Credentials`: `Specific credentials`: hadoop
+        This allows Jenkins to ssh to the EMR servers via the shell command.
+        Select the 'hadoop' ssh access key created by ansible.
+        If the ssh credentials were not configured via ansible you can manually create a key here by clicking the `Add Key` button.
+        * Kind: SSH username with private key
+        * Scope: Global
+        * Username: `hadoop`
+        * Private key: paste the analytics private key file contents directly, or copy the file to the analytics instance and point to the path.
+        * Passphrase: Leave empty for AWS-issued private key files.
+        * Description: ssh credential file
+* `Build`
+    * `Add Step` -> `Execute Shell`.
+        * Fill in `Command` field with shell script to run. See [Commands](#commands) for details.
+    * `Post build actions` -> `Add post build task`
+        * `Log text`: `Traceback`
+        * `Script`: `exit 1`
+        * `Run script only if all previous steps were successful`: `yes`
+        * `Escalate script execution status to job status`: `yes`
+    * `Post build actions` -> `Add post build action` -> `Email Notification`
+        * `Recipients` - an alert email address, e.g. `ops@example.com`
+        * `Send e-mail for every unstable build`: `yes`
+        * `Send separate e-mails to individuals who broke the build`: `no`
 * Finally, click `Save`
-
-It makes sense to try to produce even load on the server by running tasks throughout the day, i.e. not put them all to
-`0 0 * * *`, or even `H H * * *` (`H` is a hash, so it might put some tasks closely together).
 
 # Commands
 

--- a/docs/analytics/resources/emr-vars.yml
+++ b/docs/analytics/resources/emr-vars.yml
@@ -12,8 +12,8 @@ instance_groups:
     type: m4.large
     market: ON_DEMAND
   task:
-    num_instances: 2
-    type: m4.large
+    num_instances: "{{ lookup('env', 'TASK_INSTANCE_NUM')|default(2, true)|int }}"
+    type: "{{ lookup('env', 'TASK_INSTANCE_TYPE')|default('m4.large', true) }}"
     market: ON_DEMAND
 role: EMR_EC2_DefaultRole
 keypair_name: 'analytics'  # your analytics instance key pair name


### PR DESCRIPTION
Use Jenkins' "Discard old builds" configuration to ensure that we don't run out of disk space.

**JIRA issue:** OC-3613

**Testing instructions:**
Using an existing Jenkins Analytics deployment:
* Follow the steps described to create a new jenkins task, or to update an existing task.
* Ensure that the steps are clear and correct.
* Jenkins will do the rest 😄 

**Reviewer**
- [ ] Opencraft reviewer TBD