### PR TITLE
Update Analytics ElasticSearch instructions

### DIFF
--- a/docs/analytics/AWS_setup.md
+++ b/docs/analytics/AWS_setup.md
@@ -100,7 +100,7 @@ We will create an IAM role for the `analytics` EC2 instance, to give it permissi
 * Select the policy you created above (eg. `provision_emr_clusters`)
 * Hit "Create Role" on final step
 
-### ElasticSearch User
+### ElasticSearch User and Role
 
 The analytics API needs to be able to read indexes from the AWS ElasticSearch instance.
 
@@ -113,6 +113,30 @@ The analytics API needs to be able to read indexes from the AWS ElasticSearch in
   * `ANALYTICS_API_ELASTICSEARCH_AWS_SECRET_ACCESS_KEY` the Secret Access Key goes here, e.g.
       `abcdefghijklmnopqrstuvwxyz01234567899/_+`.
 * Note the user's ARN code for use when the [ElasticSearch service](#elasticsearch) is created.
+
+The EMR EC2 Instances need to be able to write to the ElasticSearch index
+
+* Go to `IAM -> Policies -> Create Policy`
+* Select "Create Your Own Policy"
+* Give it a recognizable name (eg. `elasticsearch_all`)
+* Paste this into "Policy Body" and click "Create":
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": [
+                "es:*"
+            ]
+        }
+    ]
+}
+```
+
+
 
 ### VPC DNS hostname
 

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -153,6 +153,8 @@ discussion of these environment variables.
 One can do without a `jenkins_env` file by omitting the `. /home/jenkins/jenkins_env` command from the shell script
 body, and list the environment variables in the actual shell command inline.
 
+Note that the build schedules can and should be adjusted as needed. Depending on the number and size of tracking logs, different jobs can take a differing amount of time. Some jobs can conflict while editing the s3 buckets, causing failures due to race conditions. If this kind of contention occurs, changing the schedule for jobs is perfectly fine and can often fix the problem.
+
 ## Answer Distribution
 
 In edx docs: [Performance (graded and ungraded)](http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/running_tasks.html#performance-graded-and-ungraded)


### PR DESCRIPTION
This adds instructions to create a role to allow access to ElasticSearch.
This is required for certain EMR jobs to read and write to the ElasticSearch for Analytics.