### PR TITLE
OC-4983 Changes noted for Hawthorn Analytics API

### DIFF
--- a/docs/analytics/insights.md
+++ b/docs/analytics/insights.md
@@ -21,6 +21,9 @@ If you are splitting these services across multiple EC2 instances, then you'll n
 [`analytics_insights.yml`](resources/playbooks/analytics_insights.yml) and
 [`analytics_api.yml`](resources/playbooks/analytics_api.yml).
 
+If you're planning to expose the `analytics_api` via nginx, you'll also need this
+[analytics_api.j2](resources/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2)
+
 Ensure that your playbook(s) are located on your [director instance](../shared/director.md) under `configuration/playbooks`.
 
 Variables and SSH Keys

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -229,11 +229,11 @@ Run on periodic build schedule, e.g. `H 5 * * *`.
 
 ```bash
 . /home/jenkins/jenkins_env
-export CLUSTER_NAME="InsertToMysqlCourseEnrollByCountryWorkflow Cluster"
+export CLUSTER_NAME="InsertToMysqlLastCountryPerCourseTask Cluster"
 cd $HOME
 
 NOW=`date +%s`
-analytics-configuration/automation/run-automated-task.sh InsertToMysqlCourseEnrollByCountryWorkflow \
+analytics-configuration/automation/run-automated-task.sh InsertToMysqlLastCountryPerCourseTask \
     --local-scheduler \
     --n-reduce-tasks $NUM_REDUCE_TASKS \
     --overwrite

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -175,14 +175,14 @@ ANSWER_DIST_S3_BUCKET=$HADOOP_S3_BUCKET/intermediate/answer_dist/$NOW
 
 analytics-configuration/automation/run-automated-task.sh AnswerDistributionWorkflow \
     --local-scheduler \
-    --src $TRACKING_LOGS_S3_BUCKET/logs/tracking \
+    --src "'[\"$TRACKING_LOGS_S3_BUCKET/logs/tracking\"]'" \
     --dest "$ANSWER_DIST_S3_BUCKET" \
     --name AnswerDistributionWorkflow \
     --output-root $HADOOP_S3_BUCKET/grading_reports/ \
-    --include '*tracking.log*.gz' \
+    --include "'[\"*tracking.log*.gz\"]'" \
     --manifest "$ANSWER_DIST_S3_BUCKET/manifest.txt" \
     --base-input-format "org.edx.hadoop.input.ManifestTextInputFormat" \
-    --lib-jar "$TASK_CONFIGURATION_S3_BUCKET/edx-analytics-hadoop-util.jar" \
+    --lib-jar "'[\"$TASK_CONFIGURATION_S3_BUCKET/edx-analytics-hadoop-util.jar\"]'" \
     --n-reduce-tasks $NUM_REDUCE_TASKS \
     --marker "$ANSWER_DIST_S3_BUCKET/marker"
 ```

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -239,6 +239,23 @@ analytics-configuration/automation/run-automated-task.sh InsertToMysqlLastCountr
     --overwrite
 ```
 
+## Course Activity -- bootstrap task
+
+In edx docs: [Engagement](https://edx-analytics-pipeline-reference.readthedocs.io/en/latest/running_tasks.html#id6)
+
+Run once to initialize the data set for the `InsertToMysqlCourseActivityTask` incremental task.
+
+```bash
+. /home/jenkins/jenkins_env
+export CLUSTER_NAME="LastDailyIpAddressOfUserTask Cluster"
+cd $HOME
+
+FROM_DATE=2015-01-01
+analytics-configuration/automation/run-automated-task.sh LastDailyIpAddressOfUserTask --local-scheduler \
+  --interval $(date +%Y-%m-%d -d "$FROM_DATE")-$(date +%Y-%m-%d -d "$TO_DATE") \
+  --n-reduce-tasks $NUM_REDUCE_TASKS
+```
+
 ## Course Activity
 
 In edx docs: [Engagement](http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/running_tasks.html#engagement)
@@ -249,11 +266,11 @@ Run on periodic build schedule, e.g. `H 1 * * 1`.
 
 ```bash
 . /home/jenkins/jenkins_env
-export CLUSTER_NAME="CourseActivityWeeklyTask Cluster"
+export CLUSTER_NAME="InsertToMysqlCourseActivityTask Cluster"
 cd $HOME
 
 TO_DATE=`date +%Y-%m-%d`
-analytics-configuration/automation/run-automated-task.sh CourseActivityWeeklyTask \
+analytics-configuration/automation/run-automated-task.sh InsertToMysqlCourseActivityTask \
     --local-scheduler \
     --end-date $TO_DATE \
     --weeks 24 \

--- a/docs/analytics/resources/analytics-override.cfg
+++ b/docs/analytics/resources/analytics-override.cfg
@@ -33,6 +33,9 @@ overwrite_n_days = 3
 interval_start = 2015-01-01
 overwrite_n_days = 3
 
+[user-activity]
+overwrite_n_days = 10
+
 [answer-distribution]
 valid_response_types = customresponse,choiceresponse,optionresponse,multiplechoiceresponse,numericalresponse,stringresponse,formularesponse
 

--- a/docs/analytics/resources/analytics-override.cfg
+++ b/docs/analytics/resources/analytics-override.cfg
@@ -9,8 +9,8 @@ credentials = s3://client-name-edxanalytics/edxapp_creds
 
 [event-logs]
 expand_interval = 30 days
-pattern = .*tracking.log-(?P<date>[0-9]+).*
-source = s3://client-name-tracking-logs/logs/tracking/
+pattern = [".*tracking.log-(?P<date>[0-9]+).*"]
+source = ["s3://client-name-tracking-logs/logs/tracking/"]
 
 [hive]
 warehouse_path = s3://client-name-edxanalytics/warehouse/hive/
@@ -47,7 +47,7 @@ dropoff_threshold = 0.05
 overwrite_n_days = 3
 
 [elasticsearch]
-host = https://search-client-name-analytics-es-xxxx.us-east-1.es.amazonaws.com
+host = ["https://search-client-name-analytics-es-xxxx.us-east-1.es.amazonaws.com"]
 connection_type = aws
 
 [module-engagement]

--- a/docs/analytics/resources/playbooks/analytics_api.yml
+++ b/docs/analytics/resources/playbooks/analytics_api.yml
@@ -19,8 +19,8 @@
   roles:
     - aws
     - security
-    - mysql
-    - edxlocal
+    - common_vars
+    - nginx
     - analytics_api
     - role: nginx
       nginx_sites:

--- a/docs/analytics/resources/playbooks/analytics_insights.yml
+++ b/docs/analytics/resources/playbooks/analytics_insights.yml
@@ -19,8 +19,7 @@
   roles:
     - aws
     - security
-    - mysql
-    - edxlocal
+    - common_vars
     - role: nginx
       nginx_sites:
         - insights

--- a/docs/analytics/resources/playbooks/analytics_sandbox.yml
+++ b/docs/analytics/resources/playbooks/analytics_sandbox.yml
@@ -19,12 +19,11 @@
   roles:
     - aws
     - security
-    - mysql
-    - edxlocal
-    - analytics_api
+    - common_vars
     - role: nginx
       nginx_sites:
         - insights
+    - analytics_api
     - insights
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''

--- a/docs/analytics/resources/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
+++ b/docs/analytics/resources/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
@@ -1,0 +1,61 @@
+upstream analytics_api_app_server {
+    {% for host in nginx_analytics_api_gunicorn_hosts %}
+        server {{ host }}:{{ analytics_api_gunicorn_port }} fail_timeout=0;
+    {% endfor %}
+}
+
+server {
+  listen {{ ANALYTICS_API_NGINX_PORT }} default_server;
+
+  # Nginx does not support nested condition or or conditions so
+  # there is an unfortunate mix of conditonals here.
+  {% if NGINX_REDIRECT_TO_HTTPS %}
+     {% if NGINX_HTTPS_REDIRECT_STRATEGY == "scheme" %}
+  # Redirect http to https over single instance
+  if ($scheme != "https") 
+  { 
+   set $do_redirect_to_https "true";
+  }
+ 
+    {% elif NGINX_HTTPS_REDIRECT_STRATEGY == "forward_for_proto" %}
+
+  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
+  if ($http_x_forwarded_proto = "http") 
+  {
+   set $do_redirect_to_https "true";
+  }
+     {% endif %}
+
+  # Execute the actual redirect
+  if ($do_redirect_to_https = "true")
+  {
+  return 301 https://$host$request_uri;
+  }
+  {% endif %}
+  
+  location ~ ^/static/(?P<file>.*) {
+    root {{ COMMON_DATA_DIR }}/{{ analytics_api_service_name }};
+    try_files /staticfiles/$file =404;
+  }
+
+  location / {
+    try_files $uri @proxy_to_app;
+  }
+
+  {% include "robots.j2" %}
+
+location @proxy_to_app {
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_pass http://analytics_api_app_server;
+  }
+}
+


### PR DESCRIPTION
Updates the deployment docs and resources to account for changes required for the Hawthorn Insights and Analytics Pipeline upgrade.

* Luigi lib upgrade changed the format of some critical task input parameters to use JSON lists instead of strings.
  This is especially tricky with the command-line arguments for `AnswerDistributionWorkflow`, cf [jenkins_jobs.md#answer-distribution](https://github.com/open-craft/openedx-deployment/blob/jill/hawthorn.1/docs/analytics/jenkins_jobs.md#answer-distribution) for details on how to properly escape the quotes.
* Removes some unneeded roles from the sample playbooks
* Adds the `analytics_api.j2` nginx template, which is [no longer found in the `edx:configuration` repo](https://github.com/edx/configuration/tree/master/playbooks/roles/nginx/templates/edx/app/nginx/sites-available).