### PR TITLE
WIP OC-4988 Adds s3:* to the list of permissions required by the edxanalytics role

### DIFF
--- a/docs/analytics/AWS_setup.md
+++ b/docs/analytics/AWS_setup.md
@@ -86,6 +86,7 @@ We will create an IAM role for the `analytics` EC2 instance, to give it permissi
               "iam:PassRole",
               "route53:Get*",
               "route53:List*",
+              "s3:*",
               "ec2:DescribeInstances",
               "rds:DescribeDBInstances"
           ]


### PR DESCRIPTION
WIP -- I thought this would fix the issue I'm seeing, but it didn't.  Further investigation showed that the `EMR_EC2_DefaultRole` already has `s3:*`, and since that role is given to all the EMR instances, this change is irrelevant.

But I'm leaving this open in case there is some relevant fix.

See OC-4988 for test instructions.

**Reviewers**
- [ ] @tomaszgy 