### PR TITLE
doc: fixes formatting issues with rendered documentation

### DIFF
--- a/docs/analytics/AWS_setup.md
+++ b/docs/analytics/AWS_setup.md
@@ -79,16 +79,12 @@ manually. The details may be out of date now, but are provided for reference.
 * Change directories to where you've stored your terraform `*.tf` files from [Setup](#setup-terraform).
 * From the terminal, run:
 
-   	```
-   	# Downloads the terraform provider and source templates
-   	terraform init
-
-   	# Preview the changes that will be made (check these carefully)
-   	terraform plan
-
-   	# Apply those changes
-	terraform apply
-    ```
+        # Downloads the terraform provider and source templates
+        terraform init
+        # Preview the changes that will be made (check these carefully)
+        terraform plan
+        # Apply those changes
+        terraform apply
 
 ## Upgrading existing resources
 
@@ -106,10 +102,9 @@ Once you're satisfied that the new instance is working, replace the old instance
 * Update `variables.tf` and decrement the `analytics_number_of_instances` count (back to 1).
 * Replace the old analytics instance with the new one in terraform state:
 
-    ```
-    terraform state rm 'module.analytics.aws_instance.analytics[0]'
-    terraform state mv 'module.analytics.aws_instance.analytics[1]' 'module.analytics.aws_instance.analytics[0]'
-    ```
+        terraform state rm 'module.analytics.aws_instance.analytics[0]'
+        terraform state mv 'module.analytics.aws_instance.analytics[1]' 'module.analytics.aws_instance.analytics[0]'
+
 * Update `variables.tf` to increase the `analytics_instance_iteration` counter (this is just for record purposes, doesn't affect functionality).
 * Run `terraform apply` again to move the new instance into place.
 * Manually stop/terminate the old EC2 instance once everything is verified OK.
@@ -205,4 +200,3 @@ See [Jenkins Setup](jenkins.md).
 [ElasticSearch]: https://github.com/open-craft/openedx-deployment/blob/v1.0/docs/analytics/AWS_setup.md#elasticsearch
 [IAM]: https://github.com/open-craft/openedx-deployment/blob/v1.0/docs/analytics/AWS_setup.md#iam
 [AWS profile]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
-[Director Setup]: https://github.com/open-craft/openedx-deployment/blob/v1.0/docs/shared/director.md

--- a/docs/analytics/insights.md
+++ b/docs/analytics/insights.md
@@ -117,7 +117,7 @@ OAuth2
 Insights OAuth2
 ---------------
 
-OAuth2 application setup is handled by the `oauth_client_setup` ansible role, which is also run by the openedx_native.yml playbook. So whenever you're running ansible, you need to make sure that the variables for the [`INSIGHTS_OAUTH2_APP_CLIENT_NAME` config block] are always provided, even when you're not provisioning the Insights service.
+OAuth2 application setup is handled by the `oauth_client_setup` ansible role, which is also run by the openedx_native.yml playbook. So whenever you're running ansible, you need to make sure that the variables for the [INSIGHTS_OAUTH2_APP_CLIENT_NAME config block] are always provided, even when you're not provisioning the Insights service.
 
 Note: the OAuth2 configuration for Insights is broken on juniper.master, and was fixed for later versions by [configuration PR#5967].
 
@@ -162,7 +162,7 @@ your `vars-analytics.yml`.
        `/edx/app/edxapp/*.env.vars`.
   * Successfully authenticates to LMS, but some error happens later.
     * In LMS: `invalid_request The requested redirect didn't match the client settings.` - make sure OAuth2 Client is configured with correct Insights endpoint:
-    * Go to LMS_URL/admin/oauth2/clients, select the Insights client, and make sure `Redirect` field contains
+    * Go to `LMS_URL`/admin/oauth2/clients, select the Insights client, and make sure `Redirect` field contains
                 [the correct URL](#insights-oauth2), using `http` or `https` as appropriate for your setup.
     * Check `SOCIAL_AUTH_REDIRECT_IS_HTTPS` is set to `true` for HTTPS Insights and to `false` for HTTP
                 Insights.
@@ -183,50 +183,43 @@ your `vars-analytics.yml`.
           happens in two cases:
       * Insights setting `SOCIAL_AUTH_EDX_OIDC_SECRET` does not match `Client secret` in LMS
       * Insights setting `SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY` does not match
-                `SOCIAL_AUTH_EDX_OIDC_SECRET` - should not normally happen, as they are taken from the same variable.
+        `SOCIAL_AUTH_EDX_OIDC_SECRET` - should not normally happen, as they are taken from the same variable.
 * Insights home shows 500 after logging in, and `/edx/var/log/insights/edx.log` shows something like:
 
-    ```bash
-    ProgrammingError: (1146, "Table 'dashboard.soapbox_message' doesn't exist")
-    ```
+        ProgrammingError: (1146, "Table 'dashboard.soapbox_message' doesn't exist")
+
     To fix this, run syncdb as the `insights` user:
 
-    ```bash
-    sudo -u insights -Hs
-    source ~/insights_env
-    cd ~/edx_analytics_dashboard
-    ./manage.py migrate --run-syncdb
-    ```
+        sudo -u insights -Hs
+        source ~/insights_env
+        cd ~/edx_analytics_dashboard
+        ./manage.py migrate --run-syncdb
 
     cf [openedx-analytics post](https://groups.google.com/forum/#!msg/openedx-analytics/WkqJwPERf80/WVtu155PBwAJ)
+
 * If the `ImportEnrollmentsIntoMysql` task hasn't run yet, then the home page of Insights may return a 500 error,
   and `/edx/var/log/insights/edx.log` will show something like:
 
-  ```bash
-  NotFoundError: Resource http://127.0.0.1:8100/api/v0/course_summaries/ was not found on the API server.
-  ```
+        NotFoundError: Resource http://127.0.0.1:8100/api/v0/course_summaries/ was not found on the API server.
+
   However, this only affects the home course list page.  The inner course-specific analytics pages will display fine.
+
 * Even after the `ImportEnrollmentsIntoMysql` task has run, the home page of Insights is still returning a 500 error,
   and `/edx/var/log/insights/edx.log` shows something like:
 
-  ```bash
-  ClientError: Resource "course_summaries/" returned status code 500
-  ```
+        ClientError: Resource "course_summaries/" returned status code 500
 
   And `/edx/var/log/analytics-api/edx.log` shows something like:
-
-  ```bash
-  TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
-  ```
+    
+        TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
 
   This issue happens because the analytics pipeline creates tables and fields that the Analytics API accesses, but it
   doesn't create them using the default values that the Analytics API expects.  This should be fixed properly in the
   code someday, but to work around it, run this on the `reports` database:
 
-  ```sql
-  mysql> alter table course_meta_summary_enrollment alter passing_users set default 0;
-  mysql> update course_meta_summary_enrollment set passing_users=0 where passing_users is Null;
-  ```
+        mysql> alter table course_meta_summary_enrollment alter passing_users set default 0;
+        mysql> update course_meta_summary_enrollment set passing_users=0 where passing_users is Null;
+
 * There is no data in Insights - that's actually ok, we haven't run any pipeline tasks yet.
 
 Configure Insights
@@ -289,6 +282,7 @@ We commonly enable these features:
   requires these reports.  Run the `ProblemResponseReportWorkflow` pipeline task to generate reports for download.
 
 
-[`INSIGHTS_OAUTH2_APP_CLIENT_NAME` config block]: https://github.com/edx/configuration/blob/master/playbooks/roles/oauth_client_setup/defaults/main.yml#L31-L42
+[Director Setup]: ../shared/director.md
+[INSIGHTS_OAUTH2_APP_CLIENT_NAME config block]: https://github.com/edx/configuration/blob/master/playbooks/roles/oauth_client_setup/defaults/main.yml#L31-L42
 [configuration PR#5967]: https://github.com/edx/configuration/pull/5967
 [Setup OAuth Client for Internal Services (Django Oauth Toolkit version)]: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1532395987/Setup+OAuth+Client+for+Internal+Services+Django+Oauth+Toolkit+version

--- a/docs/analytics/jenkins.md
+++ b/docs/analytics/jenkins.md
@@ -154,7 +154,7 @@ To set up the runtime environment for EMR 4.x, download these files from the Ope
 ### EMR 2.4.11
 
 AWS has dropped support for EMR 2.x.x, so use only when maintaining legacy analytics systems.  See
-[resources/emr-2.x](resources/emr-2.x) for example configuration files appropriate for this version.
+[resources/emr-2.x](resources/emr-2.x/) for example configuration files appropriate for this version.
 
 Download these files from the OpenCraft AWS account, and upload to the `client-name-analytics-emr` bucket:
 
@@ -200,17 +200,14 @@ Also, ensure these repositories are cloned and readable by the jenkins user:
 
 * `/home/jenkins/analytics-configuration`: clone the client's fork and branch, e.g.:
 
-  ```yaml
-  analytics_configuration_repo: 'https://github.com/xxx/edx-analytics-configuration.git'
-  analytics_configuration_version: 'master'
-  ```
+        analytics_configuration_repo: 'https://github.com/xxx/edx-analytics-configuration.git'
+        analytics_configuration_version: 'master'
 
 * `/home/jenkins/analytics-tasks`: clone the client's fork and branch, e.g.:
 
-  ```yaml
-  analytics_pipeline_repo: 'https://github.com/xxx/edx-analytics-pipeline.git'
-  analytics_pipeline_version: 'master'
-  ```
+        analytics_pipeline_repo: 'https://github.com/xxx/edx-analytics-pipeline.git'
+        analytics_pipeline_version: 'master'
+
 
 ## jenkins_env
 
@@ -278,13 +275,13 @@ remain as code drift that have to be carried through across version upgrades.
 
 Here are the changes required to use regions other than `us-east-1` for Open edX Analytics:
 
-* In [`jenkins_env`], set `AWS_REGION` to your desired region.
-* In [`emr-vars.yml`], set `region` to your desired region.
-* In [`emr-vars.yml`], specify the `fs.s3n.endpoint: "s3.amazonaws.com"`. See the [configuration: core-site] block for details.
-* Patch the `TASK_BRANCH` used in [`jenkins_env`] and [cloned to jenkins home] to use your desired region: [TASK_BRANCH patch]
+* In [jenkins_env], set `AWS_REGION` to your desired region.
+* In [emr-vars.yml], set `region` to your desired region.
+* In [emr-vars.yml], specify the `fs.s3n.endpoint: "s3.amazonaws.com"`. See the [configuration: core-site] block for details.
+* Patch the `TASK_BRANCH` used in [jenkins_env] and [cloned to jenkins home] to use your desired region: [TASK_BRANCH patch]
 
   Allows us to override the default S3 endpoint to use a custom region.
-1. Patch the `CONFIG_BRANCH` used in [`jenkins_env`] and [cloned to jenkins home]: [CONFIG_BRANCH patch]
+1. Patch the `CONFIG_BRANCH` used in [jenkins_env] and [cloned to jenkins home]: [CONFIG_BRANCH patch]
 
   Allows us to use the more consistent `ONDEMAND` pricing for the EMR task instances, instead of edX's default `SPOT`
   pricing.
@@ -298,7 +295,7 @@ In `ca-central-1` and other newer AWS regions, only the new [SigV4 mechanism][AW
 
 This change is required to support SigV4:
 
-* In [`emr-vars.yml`], use `release_label: 'emr-4.9.6'`
+* In [emr-vars.yml], use `release_label: 'emr-4.9.6'`
 
   Using [EMR version 4.9.6] causes EMR to use AWS Signature Version 4 exclusively to authenticate requests to Amazon S3.
 
@@ -316,17 +313,14 @@ Troubleshooting
 * EMR provisioning: ansible unable to access new EMR instance.  See [SSH Access to EMR](#emr-security-groups).
   Ensure the `ElasticMapReduduce-master` security group has inbound SSH access from the analytics security group.
 
-  Another way to provide Jenkins with access is to to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables in
+    Another way to provide Jenkins with access is to to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables in
   `jenkins_env`, however it's very important to ensure that your Jenkins logs are not publicly visible, because these
   variables will be echoed to the Console output.
 
-  To use AWS keys, create a new analytics IAM user and use the ID and KEY for these variables. Note that this user
+    To use AWS keys, create a new analytics IAM user and use the ID and KEY for these variables. Note that this user
   should have `provision_emr_clusters` policy attached, otherwise trying to provision the cluster will fail with:
-  > ClientError: An error occurred (AccessDeniedException) when calling the ListClusters operation: User: arn:aws:iam::123456789012:user/analytics_user is not authorized to perform: elasticmapreduce:ListClusters
+    > ClientError: An error occurred (AccessDeniedException) when calling the ListClusters operation: User: arn:aws:iam::123456789012:user/analytics_user is not authorized to perform: elasticmapreduce:ListClusters
 
-  ```bash
-  ClientError: An error occurred (AccessDeniedException) when calling the ListClusters operation: User: arn:aws:iam::123456789012:user/analytics_user is not authorized to perform: elasticmapreduce:ListClusters
-  ```
 * `java.lang.UnsupportedClassVersionError: org/edx/hadoop/input/ManifestTextInputFormat : Unsupported major.minor version 51.0` or `52.0`.  This error occurs if the `edx-analytics-hadoop-util.jar` you're using for your
   `manifest.lib_jar` was compiled using a different version of java than what's running on the EMR cluster.
   The easiest way to rebuild the `edx-analytics-hadoop-util.jar` using the correct java version, and the required hadoop
@@ -340,41 +334,42 @@ Troubleshooting
 
         Note the EMR Cluster ID for the `aws emr` step below.
     1. Create a virtualenv, and install awscli:
-        ```bash
-        pip install awscli
-        ```
+
+            pip install awscli
+
     1. Create an IAM user and attach the `provision_emr_clusters` policy you created above.
     1. Using the AWS Access key ID and secret, authenticate your awscli:
-        ```bash
-        aws configure
-        ```
+
+            aws configure
+
   1. Shell into the EMR cluster using the `analytics.pem` file:
-     ```bash
-     aws emr ssh --cluster-id j-xxxxxxxxxxxx --key-pair-file=analytics.pem
-     ```
+
+        aws emr ssh --cluster-id j-xxxxxxxxxxxx --key-pair-file=analytics.pem
+
   1. Clone the edx-analytics-hadoop-util repo, and build the jar file:
-    ```bash
-    git clone https://github.com/edx/edx-analytics-hadoop-util
-    cd edx-analytics-hadoop-util
-    javac -cp "/usr/lib/hadoop/client/*" org/edx/hadoop/input/ManifestTextInputFormat.java
-    jar cf edx-analytics-hadoop-util.jar org/edx/hadoop/input/ManifestTextInputFormat.class
-    ```
+
+        git clone https://github.com/edx/edx-analytics-hadoop-util
+        cd edx-analytics-hadoop-util
+        javac -cp "/usr/lib/hadoop/client/*" org/edx/hadoop/input/ManifestTextInputFormat.java
+        jar cf edx-analytics-hadoop-util.jar org/edx/hadoop/input/ManifestTextInputFormat.class
+
 
 * EMR provisioning fails on the `hive_install` step with the following in stderr log:
-   ```bash
-  Exception in thread "main" com.amazon.ws.emr.hadoop.fs.shaded.com.amazonaws.services.s3.model.AmazonS3Exception: Moved Permanently (Service: Amazon S3; Status Code: 301; Error Code: 301 Moved Permanently; Request ID: A80C873649993B68), S3 Extended Request ID: z0mA1W5N329bG+Sznq/j7G2g5gsRgKWlzqdoRmYVoCIyELiv0CNk+hmbcm2fkd7G30c7Gzs7xXk=
-  ```
+
+  > Exception in thread "main" com.amazon.ws.emr.hadoop.fs.shaded.com.amazonaws.services.s3.model.AmazonS3Exception: Moved Permanently (Service: Amazon S3; Status Code: 301; Error Code: 301 Moved Permanently; Request ID: A80C873649993B68), S3 Extended Request ID: z0mA1W5N329bG+Sznq/j7G2g5gsRgKWlzqdoRmYVoCIyELiv0CNk+hmbcm2fkd7G30c7Gzs7xXk=
+
   May occur if you're running on a region other than `us-east-1`.  See [emr-vars.yml](resources/emr-vars.yml)
   configuration for `core-site` to set the `fs.s3n.endpoint`.
 
 * EMR provisioning fails during provisioning with:
-  ```bash
-  The subnet configuration was invalid: No route to any external sources detected in Route Table for Subnet: subnet-xxxxx for VPC: vpc-xxxxx
-  ```
+
+  > The subnet configuration was invalid: No route to any external sources detected in Route Table for Subnet: subnet-xxxxx for VPC: vpc-xxxxx
+
   This could mean you have not created an Internet Gateway for your VPC. See [VPC DNS Hostname](AWS_setup.md#vpc-dns-hostname)
 
-[`jenkins_env`]: resources/jenkins_env
-[`emr-vars.yml`]: resources/emr-vars.yml
+
+[jenkins_env]: resources/jenkins_env
+[emr-vars.yml]: resources/emr-vars.yml
 [cloned to jenkins home]: #analytics-repos
 [configuration: core-site]: resources/emr-vars.yml#L39-L44
 [AWS deprecated SigV2]: https://aws.amazon.com/blogs/aws/amazon-s3-update-sigv2-deprecation-period-extended-modified/

--- a/docs/analytics/jenkins_jobs.md
+++ b/docs/analytics/jenkins_jobs.md
@@ -73,6 +73,7 @@ To create job, authenticate to Jenkins, than go to main page.
     to `0 0 * * *`, or even `H H * * *` (`H` is a hash, so it might put some tasks closely together).
 
     Refer to Jenkins help should the need for a more sophisticated schedule arise.
+
 * `Build Environment`
     * `Abort the build if it's stuck`: enable
         * `Time-out strategy`: `Absolute`
@@ -85,15 +86,16 @@ To create job, authenticate to Jenkins, than go to main page.
 
       Select the 'hadoop' ssh access key created by ansible.
 
-      If the ssh credentials were not configured via ansible you can manually create a key here by clicking       the `Add Key` button.
+      If the ssh credentials were not configured via ansible you can manually create a key here by clicking the `Add Key` button.
 
-        * Kind: SSH username with private key
-        * Scope: Global
-        * Username: `hadoop`
-        * Private key: paste the analytics private key file contents directly, or copy the file to the analytics
-          instance and point to the path.
-        * Passphrase: Leave empty for AWS-issued private key files.
-        * Description: ssh credential file
+      * Kind: SSH username with private key
+      * Scope: Global
+      * Username: `hadoop`
+      * Private key: paste the analytics private key file contents directly, or copy the file to the analytics
+        instance and point to the path.
+      * Passphrase: Leave empty for AWS-issued private key files.
+      * Description: ssh credential file
+
 * `Build`
     * `Add Step` -> `Execute Shell`.
         * Fill in `Command` field with shell script to run. See [Commands](#commands) for details.

--- a/docs/shared/director.md
+++ b/docs/shared/director.md
@@ -4,7 +4,7 @@ Director Setup
 The `director` instance is used to run ansible playbooks in the
 [`edx/configuration`](https://github.com/edx/configuration) repo.
 
-When we [deploy an instance or an upgrade](../openstack-openedx/aws-deployment.md), we don't SSH directly into the server.
+When we [deploy an instance or an upgrade](../openstack-openedx/production-deployment.md), we don't SSH directly into the server.
 Instead, we SSH to the `director`, and from `director` we SSH to the server we're deploying.
 This is done for security (the server only accepts SSH connections from `director`) and to offer us a stable environment with the right versions.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,23 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-click==7.0                # via mkdocs
-jinja2==2.10              # via mkdocs
-livereload==2.6.0         # via mkdocs
-markdown==3.0.1           # via mkdocs
-markupsafe==1.1.0         # via jinja2
+click==7.0
+    # via mkdocs
+jinja2==2.11.3
+    # via mkdocs
+livereload==2.6.0
+    # via mkdocs
+markdown==3.0.1
+    # via mkdocs
+markupsafe==1.1.0
+    # via jinja2
 mkdocs==1.0.4
-pyyaml==3.13              # via mkdocs
-six==1.12.0               # via livereload
-tornado==5.1.1            # via livereload, mkdocs
+    # via -r requirements.in
+pyyaml==5.4
+    # via mkdocs
+six==1.12.0
+    # via livereload
+tornado==5.1.1
+    # via
+    #   livereload
+    #   mkdocs


### PR DESCRIPTION
Follow-up from https://github.com/open-craft/openedx-deployment/pull/28

Fixes formatting of code blocks in HTML-rendered documentation:

* https://openedx-deployment.doc.opencraft.com/en/latest/analytics/AWS_setup/#setup-terraform
* https://openedx-deployment.doc.opencraft.com/en/latest/analytics/insights/#troubleshooting_1
* https://openedx-deployment.doc.opencraft.com/en/latest/analytics/jenkins/#analytics-repos
* https://openedx-deployment.doc.opencraft.com/en/latest/analytics/jenkins_jobs/#create-new-jenkins-job

Also applies security updates from dependabot.

**Jira ticket**

[FAL-1720](https://tasks.opencraft.com/browse/FAL-1720) (Opencraft access only)

**Testing instructions**

* In a python3 virtualenv, install the dependencies: `pip install -r requirements.txt`
* Build the HTML documentation: `mkdocs build`
* Using a web browser, view the `build/analytics/*.html` files and check that their code blocks render as expected.

**Reviewer**

- [x] @eLRuLL 